### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/.claude/skills/scientific-skills/skills/pydicom/scripts/anonymize_dicom.py
+++ b/.claude/skills/scientific-skills/skills/pydicom/scripts/anonymize_dicom.py
@@ -127,7 +127,7 @@ Examples:
         if args.verbose:
             print(f"\nAnonymized {len(result)} fields (tag names only)")
     else:
-        print(f"✗ Error: {result}")
+        print("✗ Error: Failed to anonymize DICOM file.")
         sys.exit(1)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/oimiragieo/agent-studio/security/code-scanning/11](https://github.com/oimiragieo/agent-studio/security/code-scanning/11)

In general, the fix is to ensure that potentially sensitive data (such as patient identifiers or any PHI-related details) is never written directly to logs or standard output. Instead, log only generic error messages or sanitized summaries that do not contain the tainted data.

For this specific script, the single best change is to stop including the `result` value in the error message printed at line 130. Instead, print a generic error message (optionally with the input file path if you are confident it is non‑PHI, although the code already avoids logging filenames for safety) and, if needed, log the detailed error to a secure channel outside this snippet. Since we cannot assume the presence of any logging infrastructure, the minimal safe change is to remove `{result}` from the printed string so that even if `result` ever includes PHI, it will not be exposed. No additional imports or helper functions are required.

Concretely, in `.claude/skills/scientific-skills/skills/pydicom/scripts/anonymize_dicom.py`, replace the line:

```py
130:         print(f"✗ Error: {result}")
```

with a generic message that does not include `result`, for example:

```py
130:         print("✗ Error: Failed to anonymize DICOM file.")
```

This change preserves the behavior of exiting with a nonzero status on failure while removing the clear-text logging of potentially sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
