### PR TITLE
feat(ci): harden remote release governance

### DIFF
--- a/.claude/docs/RELEASE_GOVERNANCE.md
+++ b/.claude/docs/RELEASE_GOVERNANCE.md
@@ -73,6 +73,34 @@ Example major-release gate:
 pnpm release:gate --old old.md --new new.md --type agent --commit-message "feat(agent)!: remove write tool" --migration-guide .claude/docs/MIGRATION.md
 ```
 
+## Remote PR Enforcement
+
+`Full Validation` now contains a PR-only `Release Governance` job that is authoritative for remote release classification.
+
+- It diffs governed artifacts from `github.event.pull_request.base.sha` to `github.event.pull_request.head.sha` instead of relying on changed-file heuristics alone
+- It preserves governed deletions and renames instead of flattening them into add-only snapshots
+- It writes a GitHub Actions summary so maintainers can see the required semver class without opening logs
+- It uploads durable release-governance evidence including changed-file metadata, release intent, per-artifact snapshots, and the aggregate `release-gate.json`
+- It blocks semver-major PRs unless both release-intent signaling and a migration guide are present
+
+The remote job currently auto-diffs these governed artifact classes:
+
+- `.claude/agents/**/*.md` except `CLAUDE.md`
+- `.claude/skills/**/SKILL.md`
+- `.claude/schemas/**/*.json`
+
+For remote enforcement, release intent comes from the PR title plus PR body. If a PR is breaking, the title or body must carry either:
+
+- `!` in the conventional-commit header
+- `BREAKING CHANGE:`
+
+Migration-guide detection is intentionally simple:
+
+- Preferred canonical path: `.claude/docs/MIGRATION.md`
+- Also accepted: any changed markdown file matching `*MIGRATION*.md`
+
+If no governed artifacts changed, the remote gate falls back to the non-breaking/docs-only heuristic path.
+
 ## Minor Release Path
 
 Use the minor path when the change is additive, compatibility-preserving, or a bug fix.
@@ -106,7 +134,8 @@ Use the major path when a public contract changes incompatibly:
 Required in addition to the minor path:
 
 - semver-major evidence from `release:gate`
-- migration guide present
+- PR title or body includes `!` or `BREAKING CHANGE:`
+- migration guide present at `.claude/docs/MIGRATION.md` or another changed `*MIGRATION*.md` path
 - changelog breaking-change callout
 - PR-only merge path after all required checks pass
 

--- a/.claude/lib/ci/github-actions-summary.cjs
+++ b/.claude/lib/ci/github-actions-summary.cjs
@@ -1,0 +1,166 @@
+'use strict';
+
+function renderSection(title, lines) {
+  return [`## ${title}`, ...lines].join('\n');
+}
+
+function formatBoolean(value) {
+  return value ? 'yes' : 'no';
+}
+
+function formatCount(value) {
+  const count = Number.isFinite(Number(value)) ? Number(value) : 0;
+  return `\`${count}\``;
+}
+
+function formatCode(value) {
+  return `\`${String(value)}\``;
+}
+
+function sortArtifacts(artifacts) {
+  return [...artifacts].sort((left, right) => {
+    const leftTime = Date.parse(left.createdAt || '') || 0;
+    const rightTime = Date.parse(right.createdAt || '') || 0;
+    if (rightTime !== leftTime) return rightTime - leftTime;
+    return String(left.name || '').localeCompare(String(right.name || ''));
+  });
+}
+
+function sortCategories(byCategory = {}) {
+  return Object.entries(byCategory).sort((left, right) => {
+    const countDelta = Number(right[1] || 0) - Number(left[1] || 0);
+    if (countDelta !== 0) return countDelta;
+    return left[0].localeCompare(right[0]);
+  });
+}
+
+function buildImpactedValidationSummary(payload = {}) {
+  const recommendedCommands = Array.isArray(payload.recommendedCommands)
+    ? payload.recommendedCommands.filter(
+        command => typeof command === 'string' && command.trim() !== ''
+      )
+    : [];
+  const changedFiles = Array.isArray(payload.changedFiles) ? payload.changedFiles.length : 0;
+  const lines = [
+    `- Advisory: ${formatBoolean(payload.advisory)}`,
+    `- Changed files: ${formatCount(changedFiles)}`,
+  ];
+
+  if (payload.rationale) {
+    lines.push(`- Rationale: ${String(payload.rationale)}`);
+  }
+
+  if (recommendedCommands.length === 0) {
+    lines.push('- Recommended commands: none');
+  } else {
+    lines.push('- Recommended commands:');
+    for (const command of recommendedCommands) {
+      lines.push(`  - ${formatCode(command)}`);
+    }
+  }
+
+  return renderSection('Impacted Validation', lines);
+}
+
+function buildReleaseGateSummary(payload = {}) {
+  const requiredBump = String(payload.requiredBump || 'minor');
+  const failures = Array.isArray(payload.failures) ? payload.failures : [];
+  const lines = [
+    `- Semver class: ${formatCode(requiredBump)}`,
+    `- Release path: ${formatCode(requiredBump)}`,
+    `- Docs only: ${formatBoolean(payload.docsOnly)}`,
+    `- Migration guide required: ${formatBoolean(requiredBump === 'major')}`,
+    `- Gate status: ${payload.ok === false ? 'failing' : 'passing'}`,
+  ];
+
+  if (failures.length > 0) {
+    lines.push('- Failures:');
+    for (const failure of failures) {
+      lines.push(`  - ${String(failure)}`);
+    }
+  }
+
+  return renderSection('Release Gate', lines);
+}
+
+function buildFailureEvidenceSummary(payload = {}) {
+  const artifacts = Array.isArray(payload.artifacts) ? sortArtifacts(payload.artifacts) : [];
+  const lines = [`- Artifact count: ${formatCount(artifacts.length)}`];
+
+  if (artifacts.length === 0) {
+    lines.push('- Artifacts: none');
+    return renderSection('Failure Evidence', lines);
+  }
+
+  lines.push('- Artifacts:');
+  for (const artifact of artifacts) {
+    const label = artifact.url
+      ? `[${String(artifact.name)}](${String(artifact.url)})`
+      : String(artifact.name || 'unnamed-artifact');
+    const details = [artifact.kind || 'artifact', artifact.createdAt || 'unknown-time']
+      .map(value => formatCode(value))
+      .join(', ');
+    lines.push(`  - ${label} (${details})`);
+  }
+
+  return renderSection('Failure Evidence', lines);
+}
+
+function buildFlakeOpsSummary(payload = {}) {
+  const categories = sortCategories(payload.byCategory || {});
+  const lines = [
+    `- Observation window: ${formatCode(payload.observationWindow || 'unknown')}`,
+    `- Total artifacts: ${formatCount(payload.totalArtifacts)}`,
+    `- Total occurrences: ${formatCount(payload.totalOccurrences)}`,
+    `- Actionable: ${formatBoolean(payload.actionable)}`,
+  ];
+
+  if (payload.issueUrl) {
+    const issueNumber = String(payload.issueUrl).match(/\/(\d+)(?:\/)?$/);
+    const issueLabel = issueNumber ? `#${issueNumber[1]}` : 'issue';
+    lines.push(`- Tracking issue: [${issueLabel}](${String(payload.issueUrl)})`);
+  }
+
+  if (categories.length === 0) {
+    lines.push('- Category counts: none');
+  } else {
+    lines.push('- Category counts:');
+    for (const [category, count] of categories) {
+      lines.push(`  - ${formatCode(category)}: ${formatCount(count)}`);
+    }
+  }
+
+  return renderSection('Flake Ops', lines);
+}
+
+function normalizeSummaryKind(kind) {
+  return String(kind || '')
+    .trim()
+    .toLowerCase();
+}
+
+function buildSummary(kind, payload = {}) {
+  const normalizedKind = normalizeSummaryKind(kind);
+
+  switch (normalizedKind) {
+    case 'impacted-validation':
+      return buildImpactedValidationSummary(payload);
+    case 'release-gate':
+      return buildReleaseGateSummary(payload);
+    case 'failure-evidence':
+      return buildFailureEvidenceSummary(payload);
+    case 'flake-ops':
+      return buildFlakeOpsSummary(payload);
+    default:
+      throw new Error(`Unsupported summary kind: ${kind}`);
+  }
+}
+
+module.exports = {
+  buildFailureEvidenceSummary,
+  buildFlakeOpsSummary,
+  buildImpactedValidationSummary,
+  buildReleaseGateSummary,
+  buildSummary,
+  normalizeSummaryKind,
+};

--- a/.claude/tools/cli/ci-artifact-index.cjs
+++ b/.claude/tools/cli/ci-artifact-index.cjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+
+const { wrapCLITool } = require('../../lib/utils/cli-wrapper.cjs');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  let inputPath = null;
+  let json = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const current = args[i];
+    if (current === '--json') {
+      json = true;
+      continue;
+    }
+    if (current === '--input' && args[i + 1]) {
+      inputPath = args[++i];
+    }
+  }
+
+  return {
+    inputPath,
+    json,
+  };
+}
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (value == null) continue;
+    const normalized = String(value).trim();
+    if (normalized !== '') return normalized;
+  }
+  return null;
+}
+
+function normalizeCreatedAt(value) {
+  if (value == null || String(value).trim() === '') return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function normalizeRunId(value) {
+  if (value == null || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function inferArtifactKind(record, name) {
+  const explicitKind = firstNonEmpty(record.kind, record.artifactKind, record.metadata?.kind);
+  if (explicitKind) return explicitKind.toLowerCase().replace(/[\s-]+/g, '_');
+
+  const normalizedName = String(name || '').toLowerCase();
+  if (normalizedName.includes('failure-evidence')) return 'failure_evidence';
+  if (normalizedName.includes('impacted-validation')) return 'impacted_validation';
+  if (normalizedName.includes('release-gate')) return 'release_gate';
+  if (normalizedName.includes('flake')) return 'flake_ops';
+  return 'generic';
+}
+
+function normalizeArtifactRecord(record = {}) {
+  const metadata = record.metadata || {};
+  const workflowRun = record.workflow_run || record.workflowRun || {};
+  const name = firstNonEmpty(record.name, metadata.name) || 'unnamed-artifact';
+
+  return {
+    id: record.id ?? metadata.id ?? null,
+    name,
+    workflow: firstNonEmpty(
+      record.workflow,
+      record.workflowName,
+      metadata.workflow,
+      workflowRun.name
+    ),
+    job: firstNonEmpty(record.job, record.jobName, metadata.job),
+    sha: firstNonEmpty(
+      record.sha,
+      record.head_sha,
+      record.commitSha,
+      metadata.sha,
+      workflowRun.head_sha
+    ),
+    branch: firstNonEmpty(
+      record.branch,
+      record.ref_name,
+      record.refName,
+      record.head_branch,
+      metadata.branch,
+      workflowRun.head_branch
+    ),
+    kind: inferArtifactKind(record, name),
+    createdAt: normalizeCreatedAt(record.createdAt || record.created_at || metadata.createdAt),
+    runId: normalizeRunId(record.runId || record.run_id || workflowRun.id || metadata.runId),
+    url: firstNonEmpty(record.url, record.archive_download_url, metadata.url),
+    path: firstNonEmpty(record.path, metadata.path),
+  };
+}
+
+function compareArtifacts(left, right) {
+  const leftTime = Date.parse(left.createdAt || '') || 0;
+  const rightTime = Date.parse(right.createdAt || '') || 0;
+  if (rightTime !== leftTime) return rightTime - leftTime;
+  const workflowCompare = String(left.workflow || '').localeCompare(String(right.workflow || ''));
+  if (workflowCompare !== 0) return workflowCompare;
+  const jobCompare = String(left.job || '').localeCompare(String(right.job || ''));
+  if (jobCompare !== 0) return jobCompare;
+  return String(left.name || '').localeCompare(String(right.name || ''));
+}
+
+function buildArtifactIndex(records = []) {
+  const normalizedRecords = records.map(normalizeArtifactRecord).sort(compareArtifacts);
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    artifacts: normalizedRecords,
+  };
+}
+
+function readInputRecords(inputPath) {
+  if (inputPath) {
+    const parsed = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+    if (Array.isArray(parsed)) return parsed;
+    if (Array.isArray(parsed.artifacts)) return parsed.artifacts;
+    return [parsed];
+  }
+
+  if (!process.stdin.isTTY) {
+    const raw = fs.readFileSync(0, 'utf8').trim();
+    if (raw !== '') {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed;
+      if (Array.isArray(parsed.artifacts)) return parsed.artifacts;
+      return [parsed];
+    }
+  }
+
+  return [];
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  const records = readInputRecords(opts.inputPath);
+  const index = buildArtifactIndex(records);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ index }, null, 2));
+    return;
+  }
+
+  console.log('Artifact index');
+  console.log(`- Entries: ${index.artifacts.length}`);
+  if (index.artifacts[0]) {
+    console.log(`- Latest artifact: ${index.artifacts[0].name}`);
+  }
+}
+
+const wrappedMain = wrapCLITool(main, 'ci-artifact-index');
+
+if (require.main === module) {
+  wrappedMain();
+}
+
+module.exports = {
+  buildArtifactIndex,
+  main,
+  normalizeArtifactRecord,
+  parseArgs,
+};

--- a/.claude/tools/cli/ci-artifact-index.cjs
+++ b/.claude/tools/cli/ci-artifact-index.cjs
@@ -4,6 +4,7 @@
 const fs = require('fs');
 
 const { wrapCLITool } = require('../../lib/utils/cli-wrapper.cjs');
+const { safeParseJSON } = require('../../lib/utils/safe-json.cjs');
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -121,7 +122,7 @@ function buildArtifactIndex(records = []) {
 
 function readInputRecords(inputPath) {
   if (inputPath) {
-    const parsed = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+    const parsed = safeParseJSON(fs.readFileSync(inputPath, 'utf8'), null);
     if (Array.isArray(parsed)) return parsed;
     if (Array.isArray(parsed.artifacts)) return parsed.artifacts;
     return [parsed];
@@ -130,7 +131,7 @@ function readInputRecords(inputPath) {
   if (!process.stdin.isTTY) {
     const raw = fs.readFileSync(0, 'utf8').trim();
     if (raw !== '') {
-      const parsed = JSON.parse(raw);
+      const parsed = safeParseJSON(raw, null);
       if (Array.isArray(parsed)) return parsed;
       if (Array.isArray(parsed.artifacts)) return parsed.artifacts;
       return [parsed];

--- a/.claude/tools/cli/ci-write-summary.cjs
+++ b/.claude/tools/cli/ci-write-summary.cjs
@@ -4,6 +4,7 @@
 const fs = require('fs');
 
 const { buildSummary, normalizeSummaryKind } = require('../../lib/ci/github-actions-summary.cjs');
+const { safeParseJSON } = require('../../lib/utils/safe-json.cjs');
 const { wrapCLITool } = require('../../lib/utils/cli-wrapper.cjs');
 
 function parseArgs(argv) {
@@ -28,7 +29,7 @@ function parseArgs(argv) {
       continue;
     }
     if (current === '--payload' && args[i + 1]) {
-      payload = JSON.parse(args[++i]);
+      payload = safeParseJSON(args[++i], null);
     }
   }
 
@@ -41,7 +42,7 @@ function parseArgs(argv) {
 }
 
 function readJSONFile(inputPath) {
-  return JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+  return safeParseJSON(fs.readFileSync(inputPath, 'utf8'), null);
 }
 
 function resolvePayload(kind, rawPayload) {

--- a/.claude/tools/cli/ci-write-summary.cjs
+++ b/.claude/tools/cli/ci-write-summary.cjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+
+const { buildSummary, normalizeSummaryKind } = require('../../lib/ci/github-actions-summary.cjs');
+const { wrapCLITool } = require('../../lib/utils/cli-wrapper.cjs');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  let kind = null;
+  let inputPath = null;
+  let payload = null;
+  let json = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const current = args[i];
+    if (current === '--json') {
+      json = true;
+      continue;
+    }
+    if (current === '--kind' && args[i + 1]) {
+      kind = args[++i];
+      continue;
+    }
+    if (current === '--input' && args[i + 1]) {
+      inputPath = args[++i];
+      continue;
+    }
+    if (current === '--payload' && args[i + 1]) {
+      payload = JSON.parse(args[++i]);
+    }
+  }
+
+  return {
+    json,
+    kind,
+    inputPath,
+    payload,
+  };
+}
+
+function readJSONFile(inputPath) {
+  return JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+}
+
+function resolvePayload(kind, rawPayload) {
+  const normalizedKind = normalizeSummaryKind(kind);
+  if (!rawPayload || typeof rawPayload !== 'object' || Array.isArray(rawPayload)) {
+    return rawPayload || {};
+  }
+
+  switch (normalizedKind) {
+    case 'release-gate':
+      return rawPayload.result || rawPayload;
+    case 'flake-ops':
+      return rawPayload.summary || rawPayload;
+    default:
+      return rawPayload;
+  }
+}
+
+function appendGitHubStepSummary(env, markdown) {
+  const summaryPath = String(env?.GITHUB_STEP_SUMMARY || '').trim();
+  if (summaryPath === '') {
+    return false;
+  }
+
+  fs.appendFileSync(summaryPath, `${markdown}\n`, 'utf8');
+  return true;
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  if (!opts.kind) {
+    throw new Error('Missing required --kind flag.');
+  }
+
+  const rawPayload = opts.inputPath ? readJSONFile(opts.inputPath) : opts.payload || {};
+  const payload = resolvePayload(opts.kind, rawPayload);
+  const markdown = buildSummary(opts.kind, payload);
+  const wrote = appendGitHubStepSummary(process.env, markdown);
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        {
+          kind: normalizeSummaryKind(opts.kind),
+          wrote,
+          markdown,
+        },
+        null,
+        2
+      )
+    );
+  }
+}
+
+const wrappedMain = wrapCLITool(main, 'ci-write-summary');
+
+if (require.main === module) {
+  wrappedMain();
+}
+
+module.exports = {
+  appendGitHubStepSummary,
+  main,
+  parseArgs,
+  resolvePayload,
+};

--- a/.claude/tools/cli/ci-write-summary.cjs
+++ b/.claude/tools/cli/ci-write-summary.cjs
@@ -51,6 +51,25 @@ function resolvePayload(kind, rawPayload) {
   }
 
   switch (normalizedKind) {
+    case 'impacted-validation': {
+      const plan = rawPayload.plan || rawPayload;
+      const matchedRules = Array.isArray(plan.matchedRules) ? plan.matchedRules : [];
+      const rationale =
+        matchedRules.length > 0
+          ? `Matched rules: ${matchedRules.join(', ')}`
+          : plan.conservativeFallback
+            ? 'No targeted rules matched; using conservative fallback.'
+            : undefined;
+
+      return {
+        advisory: plan.advisory !== false,
+        changedFiles: Array.isArray(plan.changedFiles) ? plan.changedFiles : [],
+        rationale,
+        recommendedCommands: Array.isArray(plan.recommendedCommands)
+          ? plan.recommendedCommands
+          : [],
+      };
+    }
     case 'release-gate':
       return rawPayload.result || rawPayload;
     case 'flake-ops':

--- a/.claude/tools/cli/release-gate.cjs
+++ b/.claude/tools/cli/release-gate.cjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('fs');
+
 const { wrapCLITool } = require('../../lib/utils/cli-wrapper.cjs');
 const { evaluateReleaseGate } = require('../../lib/ci/release-gate.cjs');
 
@@ -12,6 +14,7 @@ function parseArgs(argv) {
   let newPath = null;
   let artifactType = 'agent';
   let commitMessage = '';
+  let commitMessageFile = null;
   let migrationGuidePath = null;
 
   for (let i = 0; i < args.length; i++) {
@@ -36,6 +39,10 @@ function parseArgs(argv) {
       commitMessage = args[++i];
       continue;
     }
+    if (current === '--commit-message-file' && args[i + 1]) {
+      commitMessageFile = args[++i];
+      continue;
+    }
     if (current === '--migration-guide' && args[i + 1]) {
       migrationGuidePath = args[++i];
       continue;
@@ -51,14 +58,31 @@ function parseArgs(argv) {
     newPath,
     artifactType,
     commitMessage,
+    commitMessageFile,
     migrationGuidePath,
     changedFiles,
   };
 }
 
+function resolveCommitMessage(opts) {
+  if (typeof opts.commitMessage === 'string' && opts.commitMessage.trim() !== '') {
+    return opts.commitMessage;
+  }
+
+  if (typeof opts.commitMessageFile === 'string' && opts.commitMessageFile.trim() !== '') {
+    return fs.readFileSync(opts.commitMessageFile, 'utf8');
+  }
+
+  return '';
+}
+
 function main() {
   const opts = parseArgs(process.argv);
-  const result = evaluateReleaseGate(opts);
+  const commitMessage = resolveCommitMessage(opts);
+  const result = evaluateReleaseGate({
+    ...opts,
+    commitMessage,
+  });
 
   if (opts.json) {
     console.log(JSON.stringify({ result }, null, 2));
@@ -87,5 +111,6 @@ if (require.main === module) {
 
 module.exports = {
   parseArgs,
+  resolveCommitMessage,
   main,
 };

--- a/.github/workflows/ci-flake-ops.yml
+++ b/.github/workflows/ci-flake-ops.yml
@@ -1,0 +1,197 @@
+name: CI Flake Ops
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  ci-flake-ops:
+    name: CI Flake Ops
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Enumerate recent CI artifacts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const { owner, repo } = context.repo;
+            const workflowNames = new Set(['CI', 'Full Validation', 'Global Quality Gates', 'Observability CI']);
+            const cutoff = Date.now() - (14 * 24 * 60 * 60 * 1000);
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+              status: 'completed',
+            });
+
+            const recentRuns = runs
+              .filter(run => workflowNames.has(run.name) && Date.parse(run.created_at) >= cutoff)
+              .slice(0, 50);
+
+            const artifacts = [];
+            for (const run of recentRuns) {
+              const runArtifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner,
+                repo,
+                run_id: run.id,
+                per_page: 100,
+              });
+
+              for (const artifact of runArtifacts) {
+                if (artifact.expired) continue;
+                if (
+                  !artifact.name.startsWith('failure-evidence-') &&
+                  !artifact.name.startsWith('ci-advisory-')
+                ) {
+                  continue;
+                }
+
+                artifacts.push({
+                  id: artifact.id,
+                  name: artifact.name,
+                  workflowName: run.name,
+                  head_sha: run.head_sha,
+                  ref_name: run.head_branch,
+                  created_at: artifact.created_at,
+                  archive_download_url: artifact.archive_download_url,
+                  runId: run.id,
+                });
+              }
+            }
+
+            const outputPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'recent-artifacts.json');
+            fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+            fs.writeFileSync(outputPath, JSON.stringify(artifacts, null, 2));
+            core.setOutput('artifact-count', String(artifacts.length));
+
+      - name: Build CI artifact index
+        run: pnpm ci:artifact:index --json --input .claude/context/ci/recent-artifacts.json > .claude/context/ci/recent-artifact-index.json
+
+      - name: Build local flake report
+        run: pnpm flake:report --json > .claude/context/ci/flake-report.json
+
+      - name: Build flake summary
+        id: build-flake-summary
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const artifactIndex = JSON.parse(
+            fs.readFileSync(path.join(process.cwd(), '.claude', 'context', 'ci', 'recent-artifact-index.json'), 'utf8')
+          ).index;
+          const flakeReport = JSON.parse(
+            fs.readFileSync(path.join(process.cwd(), '.claude', 'context', 'ci', 'flake-report.json'), 'utf8')
+          ).summary;
+
+          const byCategory = {};
+          for (const artifact of artifactIndex.artifacts) {
+            const key = artifact.kind || 'generic';
+            byCategory[key] = (byCategory[key] || 0) + 1;
+          }
+
+          const failureEvidenceCount = byCategory.failure_evidence || 0;
+          const payload = {
+            observationWindow: '14d',
+            totalArtifacts: artifactIndex.artifacts.length,
+            totalOccurrences:
+              flakeReport.totalOccurrences > 0 ? flakeReport.totalOccurrences : failureEvidenceCount,
+            actionable: failureEvidenceCount > 0,
+            byCategory,
+          };
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'flake-ops-summary.json');
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `actionable=${payload.actionable}\n`);
+          NODE
+
+      - name: Write flake ops summary
+        run: pnpm ci:summary:write --kind flake-ops --input .claude/context/ci/flake-ops-summary.json
+
+      - name: Upload flake ops artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-flake-ops-${{ github.run_id }}-${{ github.run_attempt }}
+          retention-days: 14
+          path: |
+            .claude/context/ci/recent-artifacts.json
+            .claude/context/ci/recent-artifact-index.json
+            .claude/context/ci/flake-report.json
+            .claude/context/ci/flake-ops-summary.json
+
+      - name: Open or update flake ops issue
+        if: steps.build-flake-summary.outputs.actionable == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const { owner, repo } = context.repo;
+            const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'flake-ops-summary.json');
+            const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+            const title = 'CI Flake Ops Report';
+            const body = [
+              'Automated flake report detected actionable CI evidence.',
+              '',
+              `- Observation window: ${payload.observationWindow}`,
+              `- Total artifacts: ${payload.totalArtifacts}`,
+              `- Total occurrences: ${payload.totalOccurrences}`,
+              '',
+              'Category counts:',
+              ...Object.entries(payload.byCategory || {}).map(([name, count]) => `- ${name}: ${count}`),
+            ].join('\n');
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'ci-flake-ops',
+              per_page: 100,
+            });
+            const existing = openIssues.find(issue => issue.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ['ci-flake-ops'],
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           while IFS= read -r file; do
             [[ -n "$file" ]] && args+=(--file "$file")
           done < .claude/context/ci/changed-files.txt
-          pnpm validate:affected --json "${args[@]}" > .claude/context/ci/impacted-validation.json
+          node .claude/tools/cli/validate-affected.cjs --json "${args[@]}" > .claude/context/ci/impacted-validation.json
 
       - name: Write advisory impacted validation summary
         if: always()
@@ -87,11 +87,17 @@ jobs:
           while IFS= read -r file; do
             [[ -n "$file" ]] && args+=(--changed-file "$file")
           done < .claude/context/ci/changed-files.txt
-          pnpm release:gate --json "${args[@]}" > .claude/context/ci/release-gate.json
+          node .claude/tools/cli/release-gate.cjs --json "${args[@]}" > .claude/context/ci/release-gate.json
 
       - name: Write advisory release gate summary
         if: github.event_name == 'pull_request' && always()
-        run: pnpm ci:summary:write --kind release-gate --input .claude/context/ci/release-gate.json
+        shell: bash
+        run: |
+          if [[ -f .claude/context/ci/release-gate.json ]]; then
+            pnpm ci:summary:write --kind release-gate --input .claude/context/ci/release-gate.json
+          else
+            echo "Advisory release gate output missing; skipping summary."
+          fi
 
       - name: Upload advisory CI artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,91 @@ permissions:
   contents: read
 
 jobs:
+  advisory-impact-analysis:
+    name: Advisory Impact Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect changed files
+        id: changed-files
+        shell: bash
+        run: |
+          mkdir -p .claude/context/ci
+          output_path=".claude/context/ci/changed-files.txt"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+          elif [[ "${{ github.event_name }}" == "merge_group" && -n "${{ github.event.merge_group.base_sha }}" ]]; then
+            base_ref="${{ github.event.merge_group.base_sha }}"
+          elif [[ "${{ github.event.before }}" != "" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
+            base_ref="${{ github.event.before }}"
+          else
+            base_ref="$(git rev-list --max-count=1 HEAD^ 2>/dev/null || git rev-parse HEAD)"
+          fi
+          head_ref="${{ github.sha }}"
+          git diff --name-only --diff-filter=ACMR "$base_ref" "$head_ref" > "$output_path"
+          echo "count=$(wc -l < "$output_path" | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Run advisory impacted validation
+        shell: bash
+        run: |
+          mkdir -p .claude/context/ci
+          args=()
+          while IFS= read -r file; do
+            [[ -n "$file" ]] && args+=(--file "$file")
+          done < .claude/context/ci/changed-files.txt
+          pnpm validate:affected --json "${args[@]}" > .claude/context/ci/impacted-validation.json
+
+      - name: Write advisory impacted validation summary
+        if: always()
+        run: pnpm ci:summary:write --kind impacted-validation --input .claude/context/ci/impacted-validation.json
+
+      - name: Run advisory release gate
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        shell: bash
+        run: |
+          mkdir -p .claude/context/ci
+          args=()
+          while IFS= read -r file; do
+            [[ -n "$file" ]] && args+=(--changed-file "$file")
+          done < .claude/context/ci/changed-files.txt
+          pnpm release:gate --json "${args[@]}" > .claude/context/ci/release-gate.json
+
+      - name: Write advisory release gate summary
+        if: github.event_name == 'pull_request' && always()
+        run: pnpm ci:summary:write --kind release-gate --input .claude/context/ci/release-gate.json
+
+      - name: Upload advisory CI artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-advisory-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            .claude/context/ci/changed-files.txt
+            .claude/context/ci/impacted-validation.json
+            .claude/context/ci/release-gate.json
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
           else
             base_ref="$(git rev-list --max-count=1 HEAD^ 2>/dev/null || git rev-parse HEAD)"
           fi
+          if ! git rev-parse --verify --quiet "$base_ref^{commit}" >/dev/null; then
+            base_ref="$(git rev-list --max-count=1 HEAD^ 2>/dev/null || git rev-parse HEAD)"
+          fi
           head_ref="${{ github.sha }}"
           git diff --name-only --diff-filter=ACMR "$base_ref" "$head_ref" > "$output_path"
           echo "count=$(wc -l < "$output_path" | tr -d ' ')" >> "$GITHUB_OUTPUT"
@@ -75,7 +78,13 @@ jobs:
 
       - name: Write advisory impacted validation summary
         if: always()
-        run: pnpm ci:summary:write --kind impacted-validation --input .claude/context/ci/impacted-validation.json
+        shell: bash
+        run: |
+          if [[ -f .claude/context/ci/impacted-validation.json ]]; then
+            pnpm ci:summary:write --kind impacted-validation --input .claude/context/ci/impacted-validation.json
+          else
+            echo "Advisory impacted validation output missing; skipping summary."
+          fi
 
       - name: Run advisory release gate
         if: github.event_name == 'pull_request'

--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -40,6 +40,83 @@ jobs:
       - name: Validate agent-skill references
         run: pnpm validate:agent-skill-refs
 
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: agent-skill-refs
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json
+
   agent-template-contract:
     name: Agent-Template Contract
     runs-on: ubuntu-latest
@@ -64,6 +141,83 @@ jobs:
 
       - name: Validate agent-template contracts
         run: pnpm validate:agent-template-contract
+
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: agent-template-contract
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json
 
   hooks-docs:
     name: Hooks Documentation Sync
@@ -90,6 +244,83 @@ jobs:
       - name: Validate hooks documentation sync
         run: pnpm validate:hooks:docs
 
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: hooks-docs
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json
+
   registry-health:
     name: Registry Health
     runs-on: ubuntu-latest
@@ -115,6 +346,83 @@ jobs:
       - name: Validate agent registry health
         run: pnpm agents:registry:validate
 
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: registry-health
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json
+
   tests:
     name: Unit & Integration Tests
     runs-on: ubuntu-latest
@@ -139,3 +447,80 @@ jobs:
 
       - name: Run test suite
         run: pnpm test
+
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: tests
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json

--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -423,6 +423,399 @@ jobs:
           NODE
           pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json
 
+  release-governance:
+    name: Release Governance
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect changed files
+        shell: bash
+        run: |
+          mkdir -p .claude/context/ci
+          output_path=".claude/context/ci/changed-files.txt"
+          metadata_path=".claude/context/ci/changed-files.tsv"
+          base_ref="${{ github.event.pull_request.base.sha }}"
+          head_ref="${{ github.event.pull_request.head.sha }}"
+          git diff --name-status --find-renames --diff-filter=ACMRD "$base_ref" "$head_ref" > "$metadata_path"
+          : > "$output_path"
+          while IFS=$'\t' read -r status path_a path_b; do
+            [[ -z "$status" ]] && continue
+            representative_path="$path_a"
+            case "$status" in
+              R*)
+                representative_path="$path_b"
+                ;;
+            esac
+            [[ -n "$representative_path" ]] && printf '%s\n' "$representative_path" >> "$output_path"
+          done < "$metadata_path"
+
+      - name: Capture release intent
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const dir = path.join(process.cwd(), '.claude', 'context', 'ci');
+          fs.mkdirSync(dir, { recursive: true });
+          const content = `${process.env.PR_TITLE || ''}\n\n${process.env.PR_BODY || ''}`.trim();
+          fs.writeFileSync(path.join(dir, 'release-intent.txt'), `${content}\n`, 'utf8');
+          NODE
+
+      - name: Run authoritative release gate
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p .claude/context/ci/release-gate
+
+          classify_artifact() {
+            local candidate="$1"
+            case "$candidate" in
+              .claude/skills/*/SKILL.md)
+                printf 'skill\n'
+                return
+                ;;
+              .claude/agents/*.md|.claude/agents/*/*.md|.claude/agents/*/*/*.md)
+                if [[ "$(basename "$candidate")" != "CLAUDE.md" ]]; then
+                  printf 'agent\n'
+                  return
+                fi
+                ;;
+              .claude/schemas/*.json|.claude/schemas/*/*.json|.claude/schemas/*/*/*.json|.claude/schemas/*/*/*/*.json)
+                printf 'schema\n'
+                return
+                ;;
+            esac
+            printf '\n'
+          }
+
+          run_release_gate() {
+            local artifact_type="$1"
+            local source_old="$2"
+            local source_new="$3"
+
+            governed_count=$((governed_count + 1))
+
+            local old_path=".claude/context/ci/release-gate/${governed_count}-old"
+            local new_path=".claude/context/ci/release-gate/${governed_count}-new"
+            local result_path=".claude/context/ci/release-gate/${governed_count}.json"
+
+            if [[ -n "$source_old" ]] && git cat-file -e "$BASE_REF:$source_old" 2>/dev/null; then
+              git show "$BASE_REF:$source_old" > "$old_path"
+            else
+              : > "$old_path"
+            fi
+
+            if [[ -n "$source_new" ]] && git cat-file -e "$HEAD_REF:$source_new" 2>/dev/null; then
+              git show "$HEAD_REF:$source_new" > "$new_path"
+            else
+              : > "$new_path"
+            fi
+
+            args=(
+              --old "$old_path"
+              --new "$new_path"
+              --type "$artifact_type"
+              --commit-message-file .claude/context/ci/release-intent.txt
+            )
+            if [[ -n "$migration_guide" ]]; then
+              args+=(--migration-guide "$migration_guide")
+            fi
+
+            set +e
+            pnpm release:gate --json "${args[@]}" > "$result_path"
+            current_status=$?
+            set -e
+            if [[ "$current_status" -ne 0 ]]; then
+              gate_status=$current_status
+            fi
+          }
+
+          migration_guide=""
+          while IFS=$'\t' read -r status path_a path_b; do
+            [[ -z "$status" ]] && continue
+            candidate="$path_a"
+            case "$status" in
+              R*)
+                candidate="$path_b"
+                ;;
+            esac
+            if [[ -z "$migration_guide" && -n "$candidate" && "$candidate" =~ (^|/)[^/]*[Mm][Ii][Gg][Rr][Aa][Tt][Ii][Oo][Nn][^/]*\.md$ && -f "$candidate" ]]; then
+              migration_guide="$candidate"
+            fi
+          done < .claude/context/ci/changed-files.tsv
+          if [[ -z "$migration_guide" && -f .claude/docs/MIGRATION.md ]]; then
+            migration_guide=".claude/docs/MIGRATION.md"
+          fi
+
+          governed_count=0
+          gate_status=0
+
+          while IFS=$'\t' read -r status path_a path_b; do
+            [[ -z "$status" ]] && continue
+
+            old_type="$(classify_artifact "$path_a")"
+            new_type="$(classify_artifact "$path_b")"
+
+            if [[ "$status" != R* ]]; then
+              new_type="$old_type"
+            fi
+
+            if [[ -n "$old_type" && -n "$new_type" && "$old_type" != "$new_type" ]]; then
+              run_release_gate "$old_type" "$path_a" ""
+              run_release_gate "$new_type" "" "$path_b"
+              continue
+            fi
+
+            artifact_type="$new_type"
+            source_old=""
+            source_new=""
+
+            if [[ -n "$new_type" ]]; then
+              artifact_type="$new_type"
+              if [[ "$status" == R* ]]; then
+                source_new="$path_b"
+                if [[ -n "$old_type" ]]; then
+                  source_old="$path_a"
+                fi
+              else
+                source_new="$path_a"
+                source_old="$path_a"
+              fi
+            elif [[ -n "$old_type" ]]; then
+              artifact_type="$old_type"
+              source_old="$path_a"
+            else
+              continue
+            fi
+
+            run_release_gate "$artifact_type" "$source_old" "$source_new"
+          done < .claude/context/ci/changed-files.tsv
+
+          if [[ "$governed_count" -eq 0 ]]; then
+            args=(--commit-message-file .claude/context/ci/release-intent.txt)
+            while IFS= read -r file; do
+              [[ -n "$file" ]] && args+=(--changed-file "$file")
+            done < .claude/context/ci/changed-files.txt
+            if [[ -n "$migration_guide" ]]; then
+              args+=(--migration-guide "$migration_guide")
+            fi
+
+            set +e
+            pnpm release:gate --json "${args[@]}" > .claude/context/ci/release-gate.json
+            gate_status=$?
+            set -e
+            exit "$gate_status"
+          fi
+
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          function isDocFile(filePath) {
+            const normalized = String(filePath || '').replace(/\\/g, '/');
+            return (
+              normalized.endsWith('.md') ||
+              normalized.startsWith('.claude/docs/') ||
+              normalized === 'README.md' ||
+              normalized === 'CHANGELOG.md'
+            );
+          }
+
+          const root = process.cwd();
+          const changedFilesPath = path.join(root, '.claude', 'context', 'ci', 'changed-files.txt');
+          const changedFilesMetadataPath = path.join(
+            root,
+            '.claude',
+            'context',
+            'ci',
+            'changed-files.tsv'
+          );
+          const releaseGateDir = path.join(root, '.claude', 'context', 'ci', 'release-gate');
+          const changedFiles = fs
+            .readFileSync(changedFilesPath, 'utf8')
+            .split(/\r?\n/)
+            .filter(Boolean);
+          const changedFileRecords = fs.existsSync(changedFilesMetadataPath)
+            ? fs
+                .readFileSync(changedFilesMetadataPath, 'utf8')
+                .split(/\r?\n/)
+                .filter(Boolean)
+                .map(line => {
+                  const [status, pathA = '', pathB = ''] = line.split('\t');
+                  return {
+                    status,
+                    pathA,
+                    pathB,
+                  };
+                })
+            : [];
+          const rank = { patch: 0, minor: 1, major: 2 };
+          let requiredBump = 'patch';
+          const failures = new Set();
+
+          const resultFiles = fs
+            .readdirSync(releaseGateDir)
+            .filter(name => /^\d+\.json$/u.test(name))
+            .sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
+
+          for (const resultFile of resultFiles) {
+            const rawPayload = JSON.parse(
+              fs.readFileSync(path.join(releaseGateDir, resultFile), 'utf8')
+            );
+            const result = rawPayload.result || rawPayload;
+            if ((rank[result.requiredBump] || 0) > (rank[requiredBump] || 0)) {
+              requiredBump = result.requiredBump;
+            }
+            for (const failure of Array.isArray(result.failures) ? result.failures : []) {
+              failures.add(String(failure));
+            }
+          }
+
+          fs.writeFileSync(
+            path.join(root, '.claude', 'context', 'ci', 'release-gate.json'),
+            JSON.stringify(
+              {
+                result: {
+                  docsOnly:
+                    changedFileRecords.length > 0
+                      ? changedFileRecords.every(record =>
+                          [record.pathA, record.pathB].filter(Boolean).every(isDocFile)
+                        )
+                      : changedFiles.length > 0 && changedFiles.every(isDocFile),
+                  requiredBump,
+                  failures: [...failures],
+                  ok: failures.size === 0,
+                },
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+          exit "$gate_status"
+
+      - name: Write release gate summary
+        if: always()
+        run: pnpm ci:summary:write --kind release-gate --input .claude/context/ci/release-gate.json
+
+      - name: Upload release governance artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-governance-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            .claude/context/ci/changed-files.txt
+            .claude/context/ci/changed-files.tsv
+            .claude/context/ci/release-intent.txt
+            .claude/context/ci/release-gate/
+            .claude/context/ci/release-gate.json
+
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: release-governance
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json
+
   tests:
     name: Unit & Integration Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -548,7 +548,7 @@ jobs:
             fi
 
             set +e
-            pnpm release:gate --json "${args[@]}" > "$result_path"
+            node .claude/tools/cli/release-gate.cjs --json "${args[@]}" > "$result_path"
             current_status=$?
             set -e
             if [[ "$current_status" -ne 0 ]]; then
@@ -627,7 +627,7 @@ jobs:
             fi
 
             set +e
-            pnpm release:gate --json "${args[@]}" > .claude/context/ci/release-gate.json
+            node .claude/tools/cli/release-gate.cjs --json "${args[@]}" > .claude/context/ci/release-gate.json
             gate_status=$?
             set -e
             exit "$gate_status"

--- a/.github/workflows/global-quality-gates.yml
+++ b/.github/workflows/global-quality-gates.yml
@@ -38,6 +38,83 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: lint-and-format
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json
+
   validate-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -76,3 +153,80 @@ jobs:
 
       - name: Run full tests
         run: pnpm test
+
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: validate-and-test
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json

--- a/.github/workflows/observability-ci.yml
+++ b/.github/workflows/observability-ci.yml
@@ -87,3 +87,80 @@ jobs:
         run: node .claude/hooks/validation/flight-recorder-schema-gate.cjs
         env:
           FLIGHT_RECORDER_SCHEMA_GATE_STRICT: 'true'
+
+      - name: Capture failure evidence
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_STAGE: observability-ci
+        run: |
+          mkdir -p .claude/context/ci
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { writeFailureEvidence } = require('./.claude/lib/ci/failure-evidence.cjs');
+
+          const root = process.cwd();
+          const evidencePath = writeFailureEvidence(root, {
+            env: process.env,
+            failure: {
+              workflow: process.env.GITHUB_WORKFLOW,
+              job: process.env.GITHUB_JOB,
+              stage: process.env.FAILURE_STAGE,
+            },
+          });
+          const summaryPath = path.join(root, '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          fs.writeFileSync(
+            summaryPath,
+            JSON.stringify(
+              {
+                artifacts: [
+                  {
+                    name: process.env.FAILURE_ARTIFACT_NAME,
+                    kind: 'failure_evidence',
+                    createdAt: new Date().toISOString(),
+                    path: path.relative(root, evidencePath),
+                  },
+                ],
+              },
+              null,
+              2
+            )
+          );
+          NODE
+
+      - name: Upload failure evidence artifact
+        if: failure()
+        id: upload-failure-evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            .claude/context/ci/failure-evidence/
+            .claude/context/ci/failure-evidence-summary.json
+
+      - name: Write failure evidence summary
+        if: failure()
+        shell: bash
+        env:
+          FAILURE_ARTIFACT_NAME: failure-evidence-${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          FAILURE_ARTIFACT_URL: ${{ steps.upload-failure-evidence.outputs.artifact-url }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const summaryPath = path.join(process.cwd(), '.claude', 'context', 'ci', 'failure-evidence-summary.json');
+          const payload = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (Array.isArray(payload.artifacts) && payload.artifacts[0]) {
+            payload.artifacts[0].name = process.env.FAILURE_ARTIFACT_NAME;
+            if (process.env.FAILURE_ARTIFACT_URL) {
+              payload.artifacts[0].url = process.env.FAILURE_ARTIFACT_URL;
+            }
+          }
+          fs.writeFileSync(summaryPath, JSON.stringify(payload, null, 2));
+          NODE
+          pnpm ci:summary:write --kind failure-evidence --input .claude/context/ci/failure-evidence-summary.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Deterministic CI and release governance tooling** — Added repo-native flake ledger and CLI summary (`.claude/lib/ci/flake-ledger.cjs`, `.claude/tools/cli/flake-report.cjs`), failure evidence artifact capture with secret redaction (`.claude/lib/ci/failure-evidence.cjs`), impacted validation planning (`.claude/lib/ci/impacted-validation-planner.cjs`, `.claude/tools/cli/validate-affected.cjs`), and semver-aware release gating (`.claude/lib/ci/release-gate.cjs`, `.claude/tools/cli/release-gate.cjs`). Exposed the helpers through `pnpm flake:report`, `pnpm validate:affected`, and `pnpm release:gate`.
+- **Remote CI evidence and release enforcement** — `CI` now persists advisory impacted-validation and release-gate artifacts, `Full Validation` now runs a PR-only `Release Governance` gate that diffs governed agent/skill/schema artifacts from the PR base SHA to the PR head SHA while preserving deletions and renames, uploads durable release-governance evidence, and `CI Flake Ops` now aggregates recent advisory plus failure-evidence artifacts into a scheduled maintainer report with issue escalation when recurring failures become actionable.
 
 - **README agent-file counts refreshed** — Top-level README copy now reflects the current 124 tracked `.claude/agents/**/*.md` files used by `validate:sync`, including isolated worktree variants.
 
@@ -580,7 +581,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `task-manager` agent (haiku): post-pipeline task hygiene — closes stale tasks, audits 9 framework health invariants, creates fix tasks for CRITICAL/HIGH violations, produces structured health reports
 - Router drain gate Step 2.5: conditional task-manager spawn for HIGH/EPIC pipelines when stale task signals detected
 - `cron-decision` skill: decision framework for when/whether to use Claude's native cron scheduler vs alternatives (one-off tasks, manual triggers, external schedulers)
-- `scheduled-tasks` skill v1.1.0: added decision framework, official URL (https://code.claude.com/docs/en/scheduled-tasks), session-scope context note
+- `scheduled-tasks` skill v1.1.0: added decision framework, official URL (<https://code.claude.com/docs/en/scheduled-tasks>), session-scope context note
 - `@MODEL_SELECTION.md`: context window sizes table (Opus 4.6 = 1M tokens, Sonnet 4.6 = 200K tokens) and large-context routing guidance (>150K tokens → use opus)
 
 ### Fixed
@@ -2386,7 +2387,7 @@ See `.claude/docs/EXECUTION_MODE_MIGRATION.md` for detailed migration steps.
 - **Concurrent Operations**: 0% failure rate (down from 30%)
 - **Throughput**: 4.4-4.8 calls/sec under rapid stress
 
-###Files Created (17 total)
+### Files Created (17 total)
 
 - 4 test framework files (.claude/tests/)
 - 3 documentation files (.claude/docs/)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Full docs: `.claude/docs/TELEGRAM_ARCHITECTURE.md`
 - **Semver-aware release gate added**: New `pnpm release:gate` reuses artifact semver diffing, keeps docs-only changes on the non-breaking path, and enforces migration-guide plus breaking-change signaling for semver-major releases
 - **Release runbook documented**: `.claude/docs/RELEASE_GOVERNANCE.md` now documents branch naming, local verification, required remote checks, and minor-vs-major release handling
 
+### Phase 12 — Remote CI Evidence and Release Ops
+
+- **Advisory CI evidence persisted**: `CI` now uploads impacted-validation and release-gate advisory artifacts so selective validation decisions are inspectable after the run
+- **Authoritative PR release governance added**: `Full Validation` now runs a PR-only `Release Governance` job that diffs governed agent/skill/schema artifacts from the PR base SHA to the PR head SHA, preserves deletions and renames, uploads durable release evidence, reads release intent from the PR title/body, and blocks semver-major changes that do not carry both breaking-change signaling and a migration guide
+- **Scheduled flake ops added**: `CI Flake Ops` aggregates recent advisory/failure artifacts on a schedule, writes a maintainer-facing summary, and opens or updates a tracking issue when recurring failures become actionable
+
 ### Prompt Cache Optimization (Zylos-inspired)
 
 - **Envelope fingerprint**: Stable hash across spawns of same agent type (excludes per-spawn basePrompt). Enables cache hits for tools/skills/safety prefix.
@@ -403,7 +409,7 @@ Use this path if you are proposing changes to the ecosystem itself.
 pnpm run setup
 ```
 
-2. Run baseline validation:
+1. Run baseline validation:
 
 ```bash
 pnpm validate
@@ -413,7 +419,7 @@ pnpm validate:commands
 pnpm validate:routing
 ```
 
-3. Run tests relevant to your change:
+1. Run tests relevant to your change:
 
 ```bash
 pnpm test
@@ -422,14 +428,14 @@ pnpm test:tools
 pnpm test:code-indexing
 ```
 
-4. Enforce style before shipping:
+1. Enforce style before shipping:
 
 ```bash
 pnpm lint
 pnpm format:check
 ```
 
-5. Mission CLI (Factory Droid-aligned orchestration):
+1. Mission CLI (Factory Droid-aligned orchestration):
 
 ```bash
 pnpm mission:init                      # scaffold new mission bundle
@@ -458,7 +464,7 @@ pnpm manifest:generate
 pnpm routing:prototypes
 ```
 
-2. Track memory and operational health:
+1. Track memory and operational health:
 
 ```bash
 pnpm memory:status
@@ -466,14 +472,14 @@ pnpm memory:health
 pnpm worker:summary
 ```
 
-3. Run integration checks before larger pipeline runs:
+1. Run integration checks before larger pipeline runs:
 
 ```bash
 pnpm integration:headless:json
 pnpm validate:full
 ```
 
-4. Reset context safely when sessions get noisy:
+1. Reset context safely when sessions get noisy:
 
 ```bash
 pnpm context:reset --scope soft --force

--- a/package.json
+++ b/package.json
@@ -193,6 +193,8 @@
     "validate:agent-template-contract": "node .claude/tools/cli/validate-agent-template-contract.cjs",
     "validate:tool-manifest-drift": "node scripts/validation/validate-tool-manifest-drift.cjs",
     "validate:artifact-regression": "node .claude/tools/cli/validate-artifact-regression-gate.cjs",
+    "ci:summary:write": "node .claude/tools/cli/ci-write-summary.cjs",
+    "ci:artifact:index": "node .claude/tools/cli/ci-artifact-index.cjs",
     "quality:daemon:run-once": "node .claude/tools/cli/artifact-quality-daemon.cjs --mode once --json",
     "quality:daemon:start": "node .claude/tools/cli/artifact-quality-daemon.cjs --mode daemon",
     "quality:daemon:status": "node .claude/tools/cli/artifact-quality-daemon.cjs --mode status --json",

--- a/tests/lib/ci/github-actions-summary.test.cjs
+++ b/tests/lib/ci/github-actions-summary.test.cjs
@@ -1,0 +1,110 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildFailureEvidenceSummary,
+  buildFlakeOpsSummary,
+  buildImpactedValidationSummary,
+  buildReleaseGateSummary,
+} = require('../../../.claude/lib/ci/github-actions-summary.cjs');
+
+test('buildImpactedValidationSummary renders advisory recommendations deterministically', () => {
+  const markdown = buildImpactedValidationSummary({
+    advisory: true,
+    changedFiles: ['.github/workflows/ci.yml', 'package.json'],
+    rationale: 'Touched workflow wiring and package scripts.',
+    recommendedCommands: ['pnpm validate:affected --json', 'pnpm test -- --grep ci'],
+  });
+
+  assert.equal(
+    markdown,
+    [
+      '## Impacted Validation',
+      '- Advisory: yes',
+      '- Changed files: `2`',
+      '- Rationale: Touched workflow wiring and package scripts.',
+      '- Recommended commands:',
+      '  - `pnpm validate:affected --json`',
+      '  - `pnpm test -- --grep ci`',
+    ].join('\n')
+  );
+});
+
+test('buildReleaseGateSummary renders semver classification and failures deterministically', () => {
+  const markdown = buildReleaseGateSummary({
+    docsOnly: false,
+    requiredBump: 'major',
+    ok: false,
+    failures: ['Major release requires a migration guide.'],
+  });
+
+  assert.equal(
+    markdown,
+    [
+      '## Release Gate',
+      '- Semver class: `major`',
+      '- Release path: `major`',
+      '- Docs only: no',
+      '- Migration guide required: yes',
+      '- Gate status: failing',
+      '- Failures:',
+      '  - Major release requires a migration guide.',
+    ].join('\n')
+  );
+});
+
+test('buildFailureEvidenceSummary renders linked artifacts deterministically', () => {
+  const markdown = buildFailureEvidenceSummary({
+    artifacts: [
+      {
+        name: 'full-validation-tests-failure-evidence',
+        kind: 'failure_evidence',
+        url: 'https://example.test/artifacts/123',
+        createdAt: '2026-04-17T21:00:00.000Z',
+      },
+    ],
+  });
+
+  assert.equal(
+    markdown,
+    [
+      '## Failure Evidence',
+      '- Artifact count: `1`',
+      '- Artifacts:',
+      '  - [full-validation-tests-failure-evidence](https://example.test/artifacts/123) (`failure_evidence`, `2026-04-17T21:00:00.000Z`)',
+    ].join('\n')
+  );
+});
+
+test('buildFlakeOpsSummary renders actionable counts and categories deterministically', () => {
+  const markdown = buildFlakeOpsSummary({
+    actionable: true,
+    issueUrl: 'https://example.test/issues/42',
+    observationWindow: '14d',
+    totalArtifacts: 5,
+    totalOccurrences: 3,
+    byCategory: {
+      env_nondeterminism: 2,
+      test_defect: 1,
+      unknown: 0,
+    },
+  });
+
+  assert.equal(
+    markdown,
+    [
+      '## Flake Ops',
+      '- Observation window: `14d`',
+      '- Total artifacts: `5`',
+      '- Total occurrences: `3`',
+      '- Actionable: yes',
+      '- Tracking issue: [#42](https://example.test/issues/42)',
+      '- Category counts:',
+      '  - `env_nondeterminism`: `2`',
+      '  - `test_defect`: `1`',
+      '  - `unknown`: `0`',
+    ].join('\n')
+  );
+});

--- a/tests/tools/cli/ci-artifact-index.test.cjs
+++ b/tests/tools/cli/ci-artifact-index.test.cjs
@@ -1,0 +1,120 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  buildArtifactIndex,
+  normalizeArtifactRecord,
+  parseArgs,
+} = require('../../../.claude/tools/cli/ci-artifact-index.cjs');
+
+const CLI = path.join(process.cwd(), '.claude', 'tools', 'cli', 'ci-artifact-index.cjs');
+
+function makeTempDir(name) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+}
+
+function cleanupTempDir(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+test('parseArgs reads input path and json flags', () => {
+  const opts = parseArgs(['node', 'ci-artifact-index.cjs', '--json', '--input', 'artifacts.json']);
+
+  assert.equal(opts.json, true);
+  assert.equal(opts.inputPath, 'artifacts.json');
+});
+
+test('normalizeArtifactRecord maps GitHub artifact metadata to an aggregation-friendly shape', () => {
+  const normalized = normalizeArtifactRecord({
+    id: 17,
+    name: 'full-validation-tests-failure-evidence',
+    workflowName: 'Full Validation',
+    jobName: 'Unit & Integration Tests',
+    head_sha: 'abc123',
+    ref_name: 'feature/remote-ci-evidence-and-flake-ops',
+    created_at: '2026-04-17T22:15:00.000Z',
+    archive_download_url: 'https://example.test/artifacts/17.zip',
+  });
+
+  assert.deepEqual(normalized, {
+    id: 17,
+    name: 'full-validation-tests-failure-evidence',
+    workflow: 'Full Validation',
+    job: 'Unit & Integration Tests',
+    sha: 'abc123',
+    branch: 'feature/remote-ci-evidence-and-flake-ops',
+    kind: 'failure_evidence',
+    createdAt: '2026-04-17T22:15:00.000Z',
+    runId: null,
+    url: 'https://example.test/artifacts/17.zip',
+    path: null,
+  });
+});
+
+test('buildArtifactIndex sorts normalized artifacts newest-first', () => {
+  const index = buildArtifactIndex([
+    {
+      name: 'ci-impacted-validation',
+      workflowName: 'CI',
+      jobName: 'Advisory Summary',
+      head_sha: 'abc123',
+      ref_name: 'feature/remote-ci-evidence-and-flake-ops',
+      created_at: '2026-04-17T20:00:00.000Z',
+    },
+    {
+      name: 'full-validation-tests-failure-evidence',
+      workflowName: 'Full Validation',
+      jobName: 'Unit & Integration Tests',
+      head_sha: 'abc123',
+      ref_name: 'feature/remote-ci-evidence-and-flake-ops',
+      created_at: '2026-04-17T22:15:00.000Z',
+    },
+  ]);
+
+  assert.equal(index.version, 1);
+  assert.equal(index.artifacts[0].name, 'full-validation-tests-failure-evidence');
+  assert.equal(index.artifacts[1].name, 'ci-impacted-validation');
+});
+
+test('ci-artifact-index emits JSON index from input metadata', () => {
+  const tempDir = makeTempDir('ci-artifact-index');
+
+  try {
+    const inputPath = path.join(tempDir, 'artifacts.json');
+    fs.writeFileSync(
+      inputPath,
+      JSON.stringify([
+        {
+          name: 'full-validation-tests-failure-evidence',
+          workflowName: 'Full Validation',
+          jobName: 'Unit & Integration Tests',
+          head_sha: 'abc123',
+          ref_name: 'feature/remote-ci-evidence-and-flake-ops',
+          created_at: '2026-04-17T22:15:00.000Z',
+        },
+      ]),
+      'utf8'
+    );
+
+    const result = spawnSync('node', [CLI, '--json', '--input', inputPath], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout);
+
+    assert.equal(parsed.index.version, 1);
+    assert.equal(parsed.index.artifacts.length, 1);
+    assert.equal(parsed.index.artifacts[0].kind, 'failure_evidence');
+    assert.equal(parsed.index.artifacts[0].workflow, 'Full Validation');
+  } finally {
+    cleanupTempDir(tempDir);
+  }
+});

--- a/tests/tools/cli/ci-write-summary.test.cjs
+++ b/tests/tools/cli/ci-write-summary.test.cjs
@@ -94,3 +94,48 @@ test('ci-write-summary appends markdown when GITHUB_STEP_SUMMARY is set', () => 
     cleanupTempDir(tempDir);
   }
 });
+
+test('ci-write-summary unwraps validate-affected plan payloads for impacted validation summaries', () => {
+  const tempDir = makeTempDir('ci-write-summary-plan');
+
+  try {
+    const summaryPath = path.join(tempDir, 'summary.md');
+    const payloadPath = path.join(tempDir, 'payload.json');
+
+    fs.writeFileSync(
+      payloadPath,
+      JSON.stringify({
+        plan: {
+          changedFiles: ['.github/workflows/ci.yml', 'package.json'],
+          matchedRules: ['routing'],
+          conservativeFallback: false,
+          recommendedCommands: ['pnpm lint', 'pnpm validate:routing'],
+        },
+      }),
+      'utf8'
+    );
+
+    const result = spawnSync(
+      'node',
+      [CLI, '--kind', 'impacted-validation', '--input', payloadPath],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GITHUB_STEP_SUMMARY: summaryPath,
+        },
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const summary = fs.readFileSync(summaryPath, 'utf8');
+
+    assert.match(summary, /## Impacted Validation/);
+    assert.match(summary, /- Changed files: `2`/);
+    assert.match(summary, /- Recommended commands:/);
+    assert.match(summary, /`pnpm validate:routing`/);
+  } finally {
+    cleanupTempDir(tempDir);
+  }
+});

--- a/tests/tools/cli/ci-write-summary.test.cjs
+++ b/tests/tools/cli/ci-write-summary.test.cjs
@@ -1,0 +1,96 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { parseArgs } = require('../../../.claude/tools/cli/ci-write-summary.cjs');
+
+const CLI = path.join(process.cwd(), '.claude', 'tools', 'cli', 'ci-write-summary.cjs');
+
+function makeTempDir(name) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+}
+
+function cleanupTempDir(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+test('parseArgs reads kind and payload flags', () => {
+  const opts = parseArgs([
+    'node',
+    'ci-write-summary.cjs',
+    '--kind',
+    'impacted-validation',
+    '--payload',
+    '{"advisory":true}',
+  ]);
+
+  assert.equal(opts.kind, 'impacted-validation');
+  assert.deepEqual(opts.payload, { advisory: true });
+  assert.equal(opts.inputPath, null);
+});
+
+test('ci-write-summary exits successfully when GITHUB_STEP_SUMMARY is unset', () => {
+  const result = spawnSync(
+    'node',
+    [
+      CLI,
+      '--kind',
+      'impacted-validation',
+      '--payload',
+      '{"recommendedCommands":["pnpm validate:affected --json"]}',
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: '',
+      },
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), '');
+});
+
+test('ci-write-summary appends markdown when GITHUB_STEP_SUMMARY is set', () => {
+  const tempDir = makeTempDir('ci-write-summary');
+
+  try {
+    const summaryPath = path.join(tempDir, 'summary.md');
+    const payloadPath = path.join(tempDir, 'payload.json');
+
+    fs.writeFileSync(
+      payloadPath,
+      JSON.stringify({
+        docsOnly: false,
+        requiredBump: 'minor',
+        ok: true,
+        failures: [],
+      }),
+      'utf8'
+    );
+
+    const result = spawnSync('node', [CLI, '--kind', 'release-gate', '--input', payloadPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: summaryPath,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const summary = fs.readFileSync(summaryPath, 'utf8');
+
+    assert.match(summary, /## Release Gate/);
+    assert.match(summary, /- Semver class: `minor`/);
+    assert.match(summary, /- Gate status: passing/);
+  } finally {
+    cleanupTempDir(tempDir);
+  }
+});

--- a/tests/tools/cli/release-gate.test.cjs
+++ b/tests/tools/cli/release-gate.test.cjs
@@ -147,6 +147,8 @@ test('parseArgs reads release gate flags', () => {
     'agent',
     '--commit-message',
     'feat(agent)!: breaking change',
+    '--commit-message-file',
+    'release-intent.txt',
     '--migration-guide',
     'MIGRATION.md',
     '--changed-file',
@@ -158,8 +160,57 @@ test('parseArgs reads release gate flags', () => {
   assert.equal(opts.newPath, 'new.md');
   assert.equal(opts.artifactType, 'agent');
   assert.equal(opts.commitMessage, 'feat(agent)!: breaking change');
+  assert.equal(opts.commitMessageFile, 'release-intent.txt');
   assert.equal(opts.migrationGuidePath, 'MIGRATION.md');
   assert.deepEqual(opts.changedFiles, ['README.md']);
+});
+
+test('release-gate accepts commit message from file input', () => {
+  const tmpDir = makeTempDir('release-gate-commit-message-file');
+
+  try {
+    const oldFile = path.join(tmpDir, 'old.md');
+    const newFile = path.join(tmpDir, 'new.md');
+    const migrationGuide = path.join(tmpDir, 'MIGRATION.md');
+    const releaseIntent = path.join(tmpDir, 'release-intent.txt');
+
+    fs.writeFileSync(oldFile, '---\ntools: [Read, Write]\n---', 'utf8');
+    fs.writeFileSync(newFile, '---\ntools: [Read]\n---', 'utf8');
+    fs.writeFileSync(migrationGuide, '# Migration\n', 'utf8');
+    fs.writeFileSync(
+      releaseIntent,
+      'feat(agent): remove write tool\n\nBREAKING CHANGE: write capability was removed',
+      'utf8'
+    );
+
+    const result = spawnSync(
+      'node',
+      [
+        CLI,
+        '--json',
+        '--old',
+        oldFile,
+        '--new',
+        newFile,
+        '--type',
+        'agent',
+        '--commit-message-file',
+        releaseIntent,
+        '--migration-guide',
+        migrationGuide,
+      ],
+      {
+        encoding: 'utf8',
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.result.requiredBump, 'major');
+    assert.deepEqual(parsed.result.failures, []);
+  } finally {
+    cleanupTempDir(tmpDir);
+  }
 });
 
 test('release-gate emits JSON result for docs-only evaluation', () => {

--- a/tests/workflows/ci-evidence-wiring.test.cjs
+++ b/tests/workflows/ci-evidence-wiring.test.cjs
@@ -1,0 +1,37 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function readWorkflow(name) {
+  return fs.readFileSync(path.join('.github', 'workflows', name), 'utf8');
+}
+
+function readPackageJson() {
+  return JSON.parse(fs.readFileSync('package.json', 'utf8'));
+}
+
+test('ci workflow wires advisory changed-files, impacted-validation, release-gate summary, and artifact upload', () => {
+  const workflow = readWorkflow('ci.yml');
+
+  assert.match(workflow, /name:\s*Collect changed files/);
+  assert.match(workflow, /id:\s*changed-files/);
+  assert.match(workflow, /pnpm validate:affected --json/);
+  assert.match(workflow, /ci:summary:write --kind impacted-validation/);
+  assert.match(workflow, /if:\s*github\.event_name == 'pull_request'/);
+  assert.match(workflow, /pnpm release:gate --json/);
+  assert.match(workflow, /ci:summary:write --kind release-gate/);
+  assert.match(workflow, /actions\/upload-artifact@v4/);
+  assert.match(workflow, /ci-advisory-/);
+});
+
+test('package scripts expose ci summary and artifact index helpers for workflow use', () => {
+  const scripts = readPackageJson().scripts;
+
+  assert.equal(typeof scripts['ci:summary:write'], 'string');
+  assert.match(scripts['ci:summary:write'], /ci-write-summary\.cjs/);
+  assert.equal(typeof scripts['ci:artifact:index'], 'string');
+  assert.match(scripts['ci:artifact:index'], /ci-artifact-index\.cjs/);
+});

--- a/tests/workflows/ci-evidence-wiring.test.cjs
+++ b/tests/workflows/ci-evidence-wiring.test.cjs
@@ -29,6 +29,26 @@ test('ci workflow wires advisory changed-files, impacted-validation, release-gat
   assert.doesNotMatch(workflow, /pnpm release:gate --json/);
 });
 
+test('ci workflow advisory changed-files survives missing push base commits and missing summary inputs', () => {
+  const workflow = readWorkflow('ci.yml');
+
+  assert.match(
+    workflow,
+    /git rev-parse --verify --quiet "\$base_ref\^\{commit\}" >\/dev\/null/,
+    'ci.yml should verify the advisory base ref exists before diffing'
+  );
+  assert.match(
+    workflow,
+    /base_ref="\$\(git rev-list --max-count=1 HEAD\^ 2>\/dev\/null \|\| git rev-parse HEAD\)"/,
+    'ci.yml should fall back to the current branch history when the advisory base ref is unavailable'
+  );
+  assert.match(
+    workflow,
+    /if \[\[ -f \.claude\/context\/ci\/impacted-validation\.json \]\]; then/,
+    'ci.yml should skip the impacted-validation summary when the advisory JSON was not written'
+  );
+});
+
 test('package scripts expose ci summary and artifact index helpers for workflow use', () => {
   const scripts = readPackageJson().scripts;
 

--- a/tests/workflows/ci-evidence-wiring.test.cjs
+++ b/tests/workflows/ci-evidence-wiring.test.cjs
@@ -35,3 +35,32 @@ test('package scripts expose ci summary and artifact index helpers for workflow 
   assert.equal(typeof scripts['ci:artifact:index'], 'string');
   assert.match(scripts['ci:artifact:index'], /ci-artifact-index\.cjs/);
 });
+
+test('authoritative workflows upload uniquely named failure evidence artifacts and summaries', () => {
+  const workflows = ['full-validation.yml', 'global-quality-gates.yml', 'observability-ci.yml'];
+
+  for (const workflowName of workflows) {
+    const workflow = readWorkflow(workflowName);
+    assert.match(
+      workflow,
+      /failure-evidence\.cjs/,
+      `${workflowName} missing failure evidence helper`
+    );
+    assert.match(workflow, /if:\s*failure\(\)/, `${workflowName} missing failure-only step`);
+    assert.match(
+      workflow,
+      /actions\/upload-artifact@v4/,
+      `${workflowName} missing artifact upload`
+    );
+    assert.match(
+      workflow,
+      /failure-evidence-\$\{\{\s*github\.workflow\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}/,
+      `${workflowName} missing unique failure artifact naming`
+    );
+    assert.match(
+      workflow,
+      /ci:summary:write --kind failure-evidence/,
+      `${workflowName} missing failure-evidence summary step`
+    );
+  }
+});

--- a/tests/workflows/ci-evidence-wiring.test.cjs
+++ b/tests/workflows/ci-evidence-wiring.test.cjs
@@ -18,13 +18,15 @@ test('ci workflow wires advisory changed-files, impacted-validation, release-gat
 
   assert.match(workflow, /name:\s*Collect changed files/);
   assert.match(workflow, /id:\s*changed-files/);
-  assert.match(workflow, /pnpm validate:affected --json/);
+  assert.match(workflow, /node\s+\.claude\/tools\/cli\/validate-affected\.cjs\s+--json/);
   assert.match(workflow, /ci:summary:write --kind impacted-validation/);
   assert.match(workflow, /if:\s*github\.event_name == 'pull_request'/);
-  assert.match(workflow, /pnpm release:gate --json/);
+  assert.match(workflow, /node\s+\.claude\/tools\/cli\/release-gate\.cjs\s+--json/);
   assert.match(workflow, /ci:summary:write --kind release-gate/);
   assert.match(workflow, /actions\/upload-artifact@v4/);
   assert.match(workflow, /ci-advisory-/);
+  assert.doesNotMatch(workflow, /pnpm validate:affected --json/);
+  assert.doesNotMatch(workflow, /pnpm release:gate --json/);
 });
 
 test('package scripts expose ci summary and artifact index helpers for workflow use', () => {
@@ -82,7 +84,7 @@ test('full validation wires an authoritative PR-only release governance gate', (
   assert.match(workflow, /--diff-filter=ACMRD/);
   assert.match(workflow, /changed-files\.tsv/);
   assert.match(workflow, /git show/);
-  assert.match(workflow, /pnpm release:gate --json/);
+  assert.match(workflow, /node\s+\.claude\/tools\/cli\/release-gate\.cjs\s+--json/);
   assert.match(workflow, /--old/);
   assert.match(workflow, /--new/);
   assert.match(workflow, /--commit-message-file/);
@@ -103,5 +105,10 @@ test('full validation wires an authoritative PR-only release governance gate', (
     releaseGovernanceBlockMatch[0],
     /continue-on-error:\s*true/,
     'authoritative release-governance job must not be advisory'
+  );
+  assert.doesNotMatch(
+    releaseGovernanceBlockMatch[0],
+    /pnpm release:gate --json/,
+    'authoritative release-governance job must emit clean JSON without pnpm banners'
   );
 });

--- a/tests/workflows/ci-evidence-wiring.test.cjs
+++ b/tests/workflows/ci-evidence-wiring.test.cjs
@@ -64,3 +64,44 @@ test('authoritative workflows upload uniquely named failure evidence artifacts a
     );
   }
 });
+
+test('full validation wires an authoritative PR-only release governance gate', () => {
+  const workflow = readWorkflow('full-validation.yml');
+  const releaseGovernanceBlockMatch = workflow.match(
+    /release-governance:[\s\S]*?(?=\n\s{2}[a-z0-9-]+:|\n$)/
+  );
+
+  assert.match(workflow, /release-governance:/);
+  assert.match(workflow, /name:\s*Release Governance/);
+  assert.match(workflow, /if:\s*github\.event_name == 'pull_request'/);
+  assert.match(workflow, /fetch-depth:\s*0/);
+  assert.match(workflow, /Collect changed files/);
+  assert.match(workflow, /pull_request\.head\.sha/);
+  assert.match(workflow, /--name-status/);
+  assert.match(workflow, /--find-renames/);
+  assert.match(workflow, /--diff-filter=ACMRD/);
+  assert.match(workflow, /changed-files\.tsv/);
+  assert.match(workflow, /git show/);
+  assert.match(workflow, /pnpm release:gate --json/);
+  assert.match(workflow, /--old/);
+  assert.match(workflow, /--new/);
+  assert.match(workflow, /--commit-message-file/);
+  assert.match(workflow, /release-intent\.txt/);
+  assert.match(workflow, /ci:summary:write --kind release-gate/);
+  assert.match(workflow, /actions\/upload-artifact@v4/);
+  assert.match(
+    workflow,
+    /release-governance-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}/
+  );
+  assert.ok(releaseGovernanceBlockMatch, 'release-governance block should exist');
+  assert.doesNotMatch(
+    releaseGovernanceBlockMatch[0],
+    /--diff-filter=ACMR\b/,
+    'authoritative release-governance job must preserve deletions'
+  );
+  assert.doesNotMatch(
+    releaseGovernanceBlockMatch[0],
+    /continue-on-error:\s*true/,
+    'authoritative release-governance job must not be advisory'
+  );
+});

--- a/tests/workflows/ci-flake-ops-workflow.test.cjs
+++ b/tests/workflows/ci-flake-ops-workflow.test.cjs
@@ -1,0 +1,42 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function readWorkflow() {
+  return fs.readFileSync(path.join('.github', 'workflows', 'ci-flake-ops.yml'), 'utf8');
+}
+
+test('ci-flake-ops workflow runs on schedule and workflow_dispatch only', () => {
+  const workflow = readWorkflow();
+
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /pull_request:/);
+  assert.doesNotMatch(workflow, /push:/);
+});
+
+test('ci-flake-ops workflow enumerates recent artifacts and builds flake summaries', () => {
+  const workflow = readWorkflow();
+
+  assert.match(workflow, /actions\/github-script@v7/);
+  assert.match(workflow, /listWorkflowRunsForRepo/);
+  assert.match(workflow, /listWorkflowRunArtifacts/);
+  assert.match(workflow, /pnpm ci:artifact:index --json/);
+  assert.match(workflow, /pnpm flake:report --json/);
+  assert.match(workflow, /ci:summary:write --kind flake-ops/);
+  assert.match(
+    workflow,
+    /ci-flake-ops-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.run_attempt\s*\}\}/
+  );
+});
+
+test('ci-flake-ops workflow gates issue automation on actionable findings', () => {
+  const workflow = readWorkflow();
+
+  assert.match(workflow, /if:\s*steps\.build-flake-summary\.outputs\.actionable == 'true'/);
+  assert.match(workflow, /github\.rest\.issues\.(create|createComment)/);
+  assert.match(workflow, /ci-flake-ops/);
+});

--- a/tests/workflows/workflow-trigger-parity.test.cjs
+++ b/tests/workflows/workflow-trigger-parity.test.cjs
@@ -38,3 +38,11 @@ test('workflow trigger parity for creator ecosystem enforcement', () => {
     }
   }
 });
+
+test('ci-flake-ops stays manual and scheduled only', () => {
+  const workflow = readWorkflow('ci-flake-ops.yml');
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /pull_request:/);
+  assert.doesNotMatch(workflow, /push:/);
+});


### PR DESCRIPTION
## Summary
- harden `Full Validation` release governance to diff governed artifacts from PR base to PR head while preserving deletions and renames
- persist durable release-governance evidence artifacts and align migration-guide detection with documented `*MIGRATION*.md` policy
- update release governance docs and workflow tests to cover the stricter remote enforcement path

## Verification
- `node --test tests/workflows/ci-evidence-wiring.test.cjs tests/tools/cli/release-gate.test.cjs tests/workflows/ci-flake-ops-workflow.test.cjs tests/workflows/workflow-trigger-parity.test.cjs`
- `pnpm lint`
- `pnpm validate`
- `pnpm validate:status-check-governance`
- `node --test tests/benchmarks/telemetry-hotpath-latency.test.cjs tests/benchmarks/flight-recorder-throughput.test.cjs tests/lib/code-indexing/benchmark-fast-path.test.cjs tests/hooks/benchmarks/perf-regression-gate.test.cjs`
- `pnpm exec prettier --check .github/workflows/full-validation.yml .claude/tools/cli/release-gate.cjs tests/tools/cli/release-gate.test.cjs tests/workflows/ci-evidence-wiring.test.cjs .claude/docs/RELEASE_GOVERNANCE.md README.md CHANGELOG.md`
- `pnpm exec markdownlint-cli2 ".claude/docs/RELEASE_GOVERNANCE.md" "README.md" "CHANGELOG.md"`

## Notes
- This branch is stacked on `fix/release-readiness-hardening`.
- A full `pnpm test` run was started earlier, but reviewer-driven workflow fixes changed the final branch state before that long run completed, so the verification above is the fresh evidence for the committed diff.